### PR TITLE
ctan/gckanbun.sty: merely allows old documents to keep working

### DIFF
--- a/ctan/gckanbun.sty
+++ b/ctan/gckanbun.sty
@@ -2,10 +2,10 @@
 %%
 %% The original gckanbun.sty https://github.com/munepi/gckanbun was written
 %% by us many years ago.
-%% KANBUN typesetting is now implemented in the gkkanbun package,
+%% KANBUN typesetting is now implemented in the kkkanbun package,
 %% which this gckanbun.sty simply loads.
 %% The present trivial gckanbun.sty merely allows old documents to keep working.
 %%
 %% Munehiro Yamamoto <munepixyz@gmail.com>
 %% November 4, 2025
-\RequirePackage{gkkanbun}
+\RequirePackage{kkkanbun}


### PR DESCRIPTION
CTANにおいて、gkkanbunパッケージへ置き換え検討中。

* Ref. https://github.com/KKTeX/gkkanbun/pull/1